### PR TITLE
Implement filter to catch Prisma custom errors

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
-import { AppService } from './app.service';
+import { Controller } from '@nestjs/common';
 
 @Controller()
-export class AppController {
-  constructor(private readonly appService: AppService) {}
-
-  @Get()
-  getHello(): string {
-    return this.appService.getHello();
-  }
-}
+export class AppController {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,9 @@
-import { NestFactory, Reflector } from '@nestjs/core';
+import { HttpAdapterHost, NestFactory, Reflector } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { ClassSerializerInterceptor, ValidationPipe } from '@nestjs/common';
 
 import { AppModule } from './app.module';
+import { PrismaClientExceptionFilter } from './prisma-client-exception.filter';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -14,6 +15,12 @@ async function bootstrap() {
   // apply transform to all responses
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));
 
+  // apply PrismaClientExceptionFilter to entire app,
+  // requires HttpAdapterHost because it extends BaseExceptionFilter
+  const { httpAdapter } = app.get(HttpAdapterHost);
+  app.useGlobalFilters(new PrismaClientExceptionFilter(httpAdapter));
+
+  // swagger config
   const config = new DocumentBuilder()
     .setTitle('Prisma Day - NestJS Prisma Workshop')
     .setDescription('Building a REST API with NestJS and Prisma')

--- a/src/prisma-client-exception.filter.spec.ts
+++ b/src/prisma-client-exception.filter.spec.ts
@@ -1,0 +1,7 @@
+import { PrismaClientExceptionFilter } from './prisma-client-exception.filter';
+
+describe('PrismaClientExceptionFilter', () => {
+  it('should be defined', () => {
+    expect(new PrismaClientExceptionFilter()).toBeDefined();
+  });
+});

--- a/src/prisma-client-exception.filter.ts
+++ b/src/prisma-client-exception.filter.ts
@@ -12,8 +12,8 @@ export class PrismaClientExceptionFilter extends BaseExceptionFilter {
     // Refer to Prisma API reference for the error codes
     // https://www.prisma.io/docs/reference/api-reference/error-reference#prisma-client-query-engine
     switch (exception.code) {
+      // Unique constraint failed on a certain field
       case 'P2002':
-        // return conflict response
         const status = HttpStatus.CONFLICT;
         const message = exception.message.replace(/\n/g, '');
         response.status(status).json({

--- a/src/prisma-client-exception.filter.ts
+++ b/src/prisma-client-exception.filter.ts
@@ -1,13 +1,33 @@
-import { ArgumentsHost, Catch } from '@nestjs/common';
+import { ArgumentsHost, Catch, HttpStatus } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
 import { Prisma } from '@prisma/client';
+import { Response } from 'express';
 
 @Catch(Prisma.PrismaClientKnownRequestError)
 export class PrismaClientExceptionFilter extends BaseExceptionFilter {
   catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
-    // TODO: catch error exception.code
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
 
-    // default 500 error code
-    super.catch(exception, host);
+    // Refer to Prisma API reference for the error codes
+    // https://www.prisma.io/docs/reference/api-reference/error-reference#prisma-client-query-engine
+    switch (exception.code) {
+      case 'P2002':
+        // return conflict response
+        const status = HttpStatus.CONFLICT;
+        const message = exception.message.replace(/\n/g, '');
+        response.status(status).json({
+          statusCode: status,
+          message,
+        });
+        break;
+
+      // TODO: catch other error codes (eg., 'P2000' or 'P2025')
+
+      default:
+        // default 500 error code
+        super.catch(exception, host);
+        break;
+    }
   }
 }

--- a/src/prisma-client-exception.filter.ts
+++ b/src/prisma-client-exception.filter.ts
@@ -1,0 +1,13 @@
+import { ArgumentsHost, Catch } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import { Prisma } from '@prisma/client';
+
+@Catch(Prisma.PrismaClientKnownRequestError)
+export class PrismaClientExceptionFilter extends BaseExceptionFilter {
+  catch(exception: Prisma.PrismaClientKnownRequestError, host: ArgumentsHost) {
+    // TODO: catch error exception.code
+
+    // default 500 error code
+    super.catch(exception, host);
+  }
+}

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -7,7 +7,13 @@ import {
   Patch,
   Post,
 } from '@nestjs/common';
-import { ApiCreatedResponse, ApiOkResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBadRequestResponse,
+  ApiConflictResponse,
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
 import { ProductsService } from './products.service';
 import { CreateProductDto } from './dto/create-product.dto';
@@ -21,6 +27,8 @@ export class ProductsController {
 
   @Post()
   @ApiCreatedResponse({ type: ProductEntity })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiConflictResponse({ description: 'Unique constraint failed on field' })
   async create(@Body() createProductDto: CreateProductDto) {
     return new ProductEntity(
       await this.productsService.create(createProductDto),
@@ -49,6 +57,8 @@ export class ProductsController {
 
   @Patch(':id')
   @ApiCreatedResponse({ type: ProductEntity })
+  @ApiBadRequestResponse({ description: 'Bad Request' })
+  @ApiConflictResponse({ description: 'Unique constraint failed on field' })
   async update(
     @Param('id') id: string,
     @Body() updateProductDto: UpdateProductDto,


### PR DESCRIPTION
### NOTABLE CHANGES
- remove not used AppController endpoint
- add PrismaClientExceptionFilter to catch prisma known request errors
- handle unique constraint failing
- apply PrismaClientExceptionFilter to entire app
- add error response types on swagger docs