### PR TITLE
Implement forward and backward pagination of product results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -583,6 +583,11 @@
         "minimist": "^1.2.0"
       }
     },
+    "@devoxa/prisma-relay-cursor-connection": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@devoxa/prisma-relay-cursor-connection/-/prisma-relay-cursor-connection-2.0.2.tgz",
+      "integrity": "sha512-1Q/y7R7OxWtx5lpy5nn4ywSK5DGDGablOhX3ys2mXGidHshTaBMGv9semV3wPmaCBxvEtazAMgNuvkH0Kx+Yjg=="
+    },
     "@eslint/eslintrc": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "ts-node": "ts-node --compiler-options {\\\"module\\\":\\\"commonjs\\\"}"
   },
   "dependencies": {
+    "@devoxa/prisma-relay-cursor-connection": "^2.0.2",
     "@nestjs/common": "^7.6.17",
     "@nestjs/core": "^7.6.17",
     "@nestjs/platform-express": "^7.6.17",

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,14 @@ async function bootstrap() {
 
   // bind ValidationPipe to the entire application to protect all endpoints
   // from receiving invalid data
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true, // 👈 automatically transform payloads
+      transformOptions: {
+        enableImplicitConversion: true, // 👈  transform based on TS type
+      },
+    }),
+  );
 
   // apply transform to all responses
   app.useGlobalInterceptors(new ClassSerializerInterceptor(app.get(Reflector)));

--- a/src/page/api-page-response.decorator.ts
+++ b/src/page/api-page-response.decorator.ts
@@ -1,0 +1,33 @@
+import { applyDecorators, Type } from '@nestjs/common';
+import { ApiOkResponse, getSchemaPath } from '@nestjs/swagger';
+import { PageDto } from './page.dto';
+
+export const ApiPageResponse = <TModel extends Type<any>>(model: TModel) => {
+  return applyDecorators(
+    ApiOkResponse({
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(PageDto) },
+          {
+            properties: {
+              edges: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['cursor', 'node'],
+                  properties: {
+                    cursor: { type: 'string' },
+                    node: {
+                      type: 'object',
+                      $ref: getSchemaPath(model),
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    }),
+  );
+};

--- a/src/page/connection-args.dto.ts
+++ b/src/page/connection-args.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ConnectionArgsDto {
+  @ApiProperty({ required: false })
+  first?: number;
+
+  @ApiProperty({ required: false })
+  last?: number;
+
+  @ApiProperty({ required: false })
+  after?: string;
+
+  @ApiProperty({ required: false })
+  before?: string;
+}

--- a/src/page/connection-args.dto.ts
+++ b/src/page/connection-args.dto.ts
@@ -1,9 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional } from 'class-validator';
 
 export class ConnectionArgsDto {
+  @IsOptional()
+  @IsNumber()
   @ApiProperty({ required: false })
   first?: number;
 
+  @IsOptional()
+  @IsNumber()
   @ApiProperty({ required: false })
   last?: number;
 

--- a/src/page/edge.dto.ts
+++ b/src/page/edge.dto.ts
@@ -1,0 +1,4 @@
+export class EdgeDto<Record> {
+  cursor: string;
+  node: Record;
+}

--- a/src/page/page-info.dto.ts
+++ b/src/page/page-info.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class PageInfoDto {
+  @ApiProperty()
+  hasNextPage: boolean;
+
+  @ApiProperty()
+  hasPreviousPage: boolean;
+
+  @ApiProperty({ required: false, nullable: true })
+  startCursor?: string;
+
+  @ApiProperty({ required: false, nullable: true })
+  endCursor?: string;
+}

--- a/src/page/page.dto.ts
+++ b/src/page/page.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { EdgeDto } from './edge.dto';
+import { PageInfoDto } from './page-info.dto';
+
+export class PageDto<Record> {
+  edges: EdgeDto<Record>[];
+
+  @ApiProperty()
+  pageInfo: PageInfoDto;
+
+  @ApiProperty()
+  totalCount: number;
+}

--- a/src/page/page.dto.ts
+++ b/src/page/page.dto.ts
@@ -11,4 +11,8 @@ export class PageDto<Record> {
 
   @ApiProperty()
   totalCount: number;
+
+  constructor(partial: Partial<PageDto<Record>>) {
+    Object.assign(this, partial);
+  }
 }

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -5,6 +5,6 @@ import { PrismaClient } from '@prisma/client';
 export class PrismaService extends PrismaClient {
   constructor() {
     // pass PrismaClientOptions eg., logging levels or error formatting
-    super({ log: ['info'] });
+    super({ log: ['query', 'info', 'warn', 'error'] });
   }
 }

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -49,6 +49,11 @@ export class ProductsController {
     return products.map((product) => new ProductEntity(product));
   }
 
+  @Get('page')
+  async findPage() {
+    return this.productsService.findPage();
+  }
+
   @Get(':id')
   @ApiOkResponse({ type: ProductEntity })
   async findOne(@Param('id') id: string) {

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -15,7 +15,6 @@ import {
   ApiExtraModels,
   ApiOkResponse,
   ApiTags,
-  getSchemaPath,
 } from '@nestjs/swagger';
 
 import { ProductsService } from './products.service';
@@ -24,6 +23,7 @@ import { UpdateProductDto } from './dto/update-product.dto';
 import { ProductEntity } from './entities/product.entity';
 import { ConnectionArgsDto } from '../page/connection-args.dto';
 import { PageDto } from '../page/page.dto';
+import { ApiPageResponse } from '../page/api-page-response.decorator';
 
 @Controller('products')
 @ApiTags('Products')
@@ -56,28 +56,7 @@ export class ProductsController {
   }
 
   @Get('page')
-  @ApiOkResponse({
-    schema: {
-      allOf: [
-        { $ref: getSchemaPath(PageDto) },
-        {
-          properties: {
-            edges: {
-              type: 'array',
-              items: {
-                type: 'object',
-                required: ['cursor', 'node'],
-                properties: {
-                  cursor: { type: 'string' },
-                  node: { type: 'object', $ref: getSchemaPath(ProductEntity) },
-                },
-              },
-            },
-          },
-        },
-      ],
-    },
-  })
+  @ApiPageResponse(ProductEntity)
   findPage(@Query() connectionArgs: ConnectionArgsDto) {
     return this.productsService.findPage(connectionArgs);
   }

--- a/src/products/products.controller.ts
+++ b/src/products/products.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
 } from '@nestjs/common';
 import {
   ApiBadRequestResponse,
@@ -19,6 +20,7 @@ import { ProductsService } from './products.service';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { ProductEntity } from './entities/product.entity';
+import { ConnectionArgsDto } from '../page/connection-args.dto';
 
 @Controller('products')
 @ApiTags('Products')
@@ -50,8 +52,8 @@ export class ProductsController {
   }
 
   @Get('page')
-  async findPage() {
-    return this.productsService.findPage();
+  findPage(@Query() connectionArgs: ConnectionArgsDto) {
+    return this.productsService.findPage(connectionArgs);
   }
 
   @Get(':id')

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { findManyCursorConnection } from '@devoxa/prisma-relay-cursor-connection';
+import { Prisma } from '@prisma/client';
 
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
@@ -22,10 +23,19 @@ export class ProductsService {
   }
 
   async findPage() {
+    const where: Prisma.ProductWhereInput = { published: true };
+
     return await findManyCursorConnection(
       // 👇 args contain take, skip and cursor
-      (args) => this.prisma.product.findMany(args),
-      () => this.prisma.product.count(),
+      (args) =>
+        this.prisma.product.findMany({
+          ...args, // 👈 apply paging arguments
+          where,
+        }),
+      () =>
+        this.prisma.product.count({
+          where, // 👈 apply paging arguments
+        }),
       { first: 5 }, // 👈 returns all product records
     );
   }

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { findManyCursorConnection } from '@devoxa/prisma-relay-cursor-connection';
+
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { PrismaService } from '../prisma/prisma.service';
@@ -17,6 +19,15 @@ export class ProductsService {
 
   findDrafts() {
     return this.prisma.product.findMany({ where: { published: false } });
+  }
+
+  async findPage() {
+    return await findManyCursorConnection(
+      // 👇 args contain take, skip and cursor
+      (args) => this.prisma.product.findMany(args),
+      () => this.prisma.product.count(),
+      { first: 5 }, // 👈 returns all product records
+    );
   }
 
   findOne(id: string) {

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -2,9 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { findManyCursorConnection } from '@devoxa/prisma-relay-cursor-connection';
 import { Prisma } from '@prisma/client';
 
+import { PrismaService } from '../prisma/prisma.service';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
-import { PrismaService } from '../prisma/prisma.service';
+import { ConnectionArgsDto } from '../page/connection-args.dto';
 
 @Injectable()
 export class ProductsService {
@@ -22,7 +23,7 @@ export class ProductsService {
     return this.prisma.product.findMany({ where: { published: false } });
   }
 
-  async findPage() {
+  async findPage(connectionArgs: ConnectionArgsDto) {
     const where: Prisma.ProductWhereInput = { published: true };
 
     return await findManyCursorConnection(
@@ -36,7 +37,7 @@ export class ProductsService {
         this.prisma.product.count({
           where, // 👈 apply paging arguments
         }),
-      { first: 5 }, // 👈 returns all product records
+      connectionArgs, // 👈 use connection arguments
     );
   }
 

--- a/src/products/products.service.ts
+++ b/src/products/products.service.ts
@@ -3,9 +3,11 @@ import { findManyCursorConnection } from '@devoxa/prisma-relay-cursor-connection
 import { Prisma } from '@prisma/client';
 
 import { PrismaService } from '../prisma/prisma.service';
+import { ProductEntity } from './entities/product.entity';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
 import { ConnectionArgsDto } from '../page/connection-args.dto';
+import { PageDto } from '../page/page.dto';
 
 @Injectable()
 export class ProductsService {
@@ -26,7 +28,7 @@ export class ProductsService {
   async findPage(connectionArgs: ConnectionArgsDto) {
     const where: Prisma.ProductWhereInput = { published: true };
 
-    return await findManyCursorConnection(
+    const productPage = await findManyCursorConnection(
       // 👇 args contain take, skip and cursor
       (args) =>
         this.prisma.product.findMany({
@@ -38,7 +40,14 @@ export class ProductsService {
           where, // 👈 apply paging arguments
         }),
       connectionArgs, // 👈 use connection arguments
+      {
+        recordToEdge: (record) => ({
+          node: new ProductEntity(record), // 👈 instance to transform price
+        }),
+      },
     );
+
+    return new PageDto<ProductEntity>(productPage); // 👈 instance as this object is returned
   }
 
   findOne(id: string) {


### PR DESCRIPTION
### NOTABLE CHANGES
- add @devoxa/prisma-relay-cursor-connection dependency
- wire up findManyCursorConnection and return all product records
- return paginated product results where published is true
- create and pass a ConnectionArgs DTO to findPage request
- enable implicit conversion of DTO types to TS type
- create schema response definition for findPage endpoint
- create a generic ApiPageResponse decorator for reuse on all paginated endpoints
- transform the price on the page edges results to a number instead of a string